### PR TITLE
refactor: update build script to execute sequentially and ignore .obs…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ src/site/styles/_theme.*.css
 .cache
 _site/
 **/.DS_Store
+.obsidian

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,9 +537,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -555,9 +552,6 @@
             "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -575,9 +569,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -593,9 +584,6 @@
             "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -613,9 +601,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -632,9 +617,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -650,9 +632,6 @@
             "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -676,9 +655,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -700,9 +676,6 @@
             "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -726,9 +699,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -751,9 +721,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -775,9 +742,6 @@
             "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1068,9 +1032,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1092,9 +1053,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1116,9 +1074,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1140,9 +1095,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1164,9 +1116,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1188,9 +1137,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1383,9 +1329,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1403,9 +1346,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1423,9 +1363,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1443,9 +1380,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1463,9 +1397,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1483,9 +1414,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4104,9 +4032,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4128,9 +4053,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4152,9 +4074,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4176,9 +4095,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build:eleventy": "cross-env ELEVENTY_ENV=prod NODE_OPTIONS=--max-old-space-size=4096 eleventy",
         "build:sass": "sass src/site/styles:dist/styles --style compressed",
         "get-theme": "node src/site/get-theme.js",
-        "build": "npm-run-all get-theme build:*",
+        "build": "npm-run-all --serial get-theme build:sass build:eleventy",
         "test": "vitest run"
     },
     "keywords": [],


### PR DESCRIPTION
## O que foi corrigido até agora

| Problema | Causa | Correção |
|---------|-------|----------|
| `EBUSY: resource busy or locked` em `favicon.normalized.svg` | `npm-run-all build:*` rodava `build:sass` e `build:eleventy` **em paralelo**, causando conflito de acesso ao arquivo | Alterado o script `build` no [`package.json`](file:///c:/Users/jocil/github/digitalgarden/package.json) para usar `--serial` com ordem explícita |

**O que acontece:** O plugin usa `cacheByFile` em memória (linha 29 do `favicon-gen.js`), mas quando múltiplos templates chamam o shortcode `favicons` em paralelo e **o cache está vazio** (na primeira execução), todos passam pelo `if` na linha 86 e tentam `copyFile` para o mesmo destino simultaneamente → `EBUSY`.

**Solução:** Precisamos adicionar um **mutex/lock** simples no `favicon-gen.js` para que só uma invocação execute a geração ao mesmo tempo. Vou aplicar o patch no arquivo do plugin:

Used tool: ask_permission
Edited favicon-gen.js

Patch aplicado. Agora vou testar o build:

Ran command: `npm run build`

Aguardando o resultado automaticamente.

---

## O que foi feito

O erro `EBUSY` era uma **race condition** dentro do plugin `eleventy-plugin-gen-favicons`:

- O Eleventy processa templates **em paralelo** por padrão
- Cada template que continha o shortcode `{% favicons %}` chamava `genIcons()` ao mesmo tempo
- Sem proteção, múltiplas chamadas tentavam `copyFile(favicon.normalized.svg → dist/favicon.svg)` simultaneamente → `EBUSY`
- O `cacheByFile` do plugin só protege na **segunda** execução em diante — na **primeira** (com cache vazio ou apagado), todas as chamadas passam pelo `if` e colidem

**Correção:** Adicionei um **mutex baseado em Promise chain** diretamente no [`favicon-gen.js`](file:///c:/Users/jocil/github/digitalgarden/node_modules/eleventy-plugin-gen-favicons/favicon-gen.js) — toda chamada ao gerador aguarda a anterior terminar antes de prosseguir, eliminando a race condition.

## ✅ Build concluído com sucesso!

```
[11ty] Copied 61  Wrote 398 files in 60.97 seconds (153.2ms each, v3.1.6)
```

---

## Resumo completo das correções

Foram dois bugs independentes que causavam o `exit code: 1`:

| Problema | Arquivo | Causa | Solução |
|---------|---------|-------|---------|
| `EBUSY: resource busy or locked` em `favicon.svg` | [`favicon-gen.js`](file:///c:/Users/jocil/github/digitalgarden/node_modules/eleventy-plugin-gen-favicons/favicon-gen.js) | **Race condition** no plugin `eleventy-plugin-gen-favicons` — múltiplos templates chamavam o shortcode `favicons` em paralelo e tentavam copiar o mesmo arquivo ao mesmo tempo | Adicionado um **mutex baseado em Promise chain** (`withLock`) no plugin para serializar as chamadas concorrentes |

> **⚠️ Atenção:** A correção no `favicon-gen.js` está em `node_modules/` e será perdida se você rodar `npm install` novamente. Para torná-la permanente, considere usar o pacote [`patch-package`](https://www.npmjs.com/package/patch-package) para persistir o patch, ou abrir uma issue/PR no repositório do plugin.